### PR TITLE
Add `--multi-namespaes` `-m` flags for compatibility of `kubectl`

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This is a `kubectl` plugin for finding decoded secret data.
 Since `kubectl` only outputs base64-encoded secrets, it makes it difficult to check the secret value.
-This plugin helps finding a decoded secret data you want by variety of options.
+It helps finding a decoded secret data you want with productive search flags.
 
 ## Usage
 
@@ -15,14 +15,15 @@ Usage:
   kubectl-secret-data [flags]
 
 Flags:
-  -A, --all-namespace       If present, find secrets from all namespaces
-      --cluster string      The name of the kubeconfig context to use
-      --context string      The name of the kubeconfig cluster to use
-  -h, --help                help for kubectl-secret-data
-      --kubeconfig string   Path to the kubeconfig file to use for CLI requests
-  -n, --namespace string    The namespaces where secrets exist. You can set multiple namespaces separated by ","
-  -o, --output string       The format of the result (default "yaml")
-  -E, --regex string        The regular expression of secret name
+  -A, --all-namespace             If present, find secrets from all namespaces
+      --cluster string            The name of the kubeconfig context to use
+      --context string            The name of the kubeconfig cluster to use
+  -h, --help                      help for kubectl-secret-data
+      --kubeconfig string         Path to the kubeconfig file to use for CLI requests
+  -m, --multi-namespaces string   The multi namespacess separated by "," where secrets exist.
+  -n, --namespace string          The namespaces where secrets exist
+  -o, --output string             The format of the result (default "yaml")
+  -E, --regex string              The regular expression of secret name
 ```
 
 ### Example
@@ -102,7 +103,9 @@ List all secret data in `ns-1` and `ns-2` in `json`.
 **You can specify multiple namespace.**
 
 ```shell
-kubectl-secret-data -n ns-1,ns-2 -o json
+kubectl-secret-data -m ns-1,ns-2 -o json
+#OR
+kubectl-secret-data --multi-namespaces ns-1,ns-2 -o json
 ```
 
 <details>
@@ -155,7 +158,7 @@ kubectl-secret-data -n ns-1,ns-2 -o json
 
 </details>
 
-List all secret data in `ns-1` in `json` with a regex.
+List secret data by matching regex in `ns-1` in `json`.
 
 ```shell
 kubectl-secret-data -n ns-1 -E "^super-.*"
@@ -194,7 +197,7 @@ See the [release](https://github.com/kskumgk63/kubectl-secret-data/releases) pag
 #### Linux
 
 ```bash
-curl -L -o kubectl-secret-data.tar.gz https://github.com/kskumgk63/kubectl-secret-data/releases/download/v0.1.0/kubectl-secret-data_0.1.0_Linux_arm64.tar.gz
+curl -L -o kubectl-secret-data.tar.gz https://github.com/kskumgk63/kubectl-secret-data/releases/download/v0.2.0/kubectl-secret-data_0.2.0_Linux_arm64.tar.gz
 tar -xvf kubectl-secret-data.tar.gz
 mv kubectl-secret-data /usr/local/bin/kubectl-secret-data
 ```
@@ -202,7 +205,7 @@ mv kubectl-secret-data /usr/local/bin/kubectl-secret-data
 #### OSX
 
 ```bash
-curl -L -o kubectl-secret-data.tar.gz https://github.com/kskumgk63/kubectl-secret-data/releases/download/v0.1.0/kubectl-secret-data_0.1.0_Darwin_arm64.tar.gz
+curl -L -o kubectl-secret-data.tar.gz https://github.com/kskumgk63/kubectl-secret-data/releases/download/v0.2.0/kubectl-secret-data_0.2.0_Darwin_arm64.tar.gz
 tar -xvf kubectl-secret-data.tar.gz
 mv kubectl-secret-data /usr/local/bin/kubectl-secret-data
 ```

--- a/find.go
+++ b/find.go
@@ -111,7 +111,7 @@ func secretCommands(ctx context.Context, name string, opt options) ([]*exec.Cmd,
 			ns = append(ns, n.Name)
 		}
 	} else {
-		ns = strings.Split(opt.Namespace, ",")
+		ns = strings.Split(opt.MultiNamespaces, ",")
 	}
 	cmds := make([]*exec.Cmd, len(ns))
 	for i, n := range ns {

--- a/main.go
+++ b/main.go
@@ -36,20 +36,22 @@ func newCmd() *cobra.Command {
 }
 
 type options struct {
-	Namespace    string
-	KubeContext  string
-	KubeConfing  string
-	Cluster      string
-	Output       string
-	Regex        string
-	AllNamespace bool
+	Namespace       string
+	MultiNamespaces string
+	KubeContext     string
+	KubeConfing     string
+	Cluster         string
+	Output          string
+	Regex           string
+	AllNamespace    bool
 }
 
 func newOptions() options {
 	return options{
-		Namespace:    "",
-		Output:       "yaml",
-		AllNamespace: false,
+		Namespace:       "",
+		MultiNamespaces: "",
+		Output:          "yaml",
+		AllNamespace:    false,
 	}
 }
 
@@ -68,7 +70,8 @@ func (o *options) toKubectlOptions() []string {
 }
 
 func (o *options) parseFlags(cmd *cobra.Command) {
-	cmd.PersistentFlags().StringVarP(&o.Namespace, "namespace", "n", o.Namespace, `The namespaces where secrets exist. You can set multiple namespaces separated by ","`)
+	cmd.PersistentFlags().StringVarP(&o.Namespace, "namespace", "n", o.Namespace, "The namespaces where secrets exist")
+	cmd.PersistentFlags().StringVarP(&o.MultiNamespaces, "multi-namespaces", "m", o.MultiNamespaces, `The multi namespacess separated by "," where secrets exist.`)
 	cmd.PersistentFlags().StringVar(&o.KubeContext, "context", o.KubeContext, "The name of the kubeconfig cluster to use")
 	cmd.PersistentFlags().StringVar(&o.Cluster, "cluster", o.Cluster, "The name of the kubeconfig context to use")
 	cmd.PersistentFlags().StringVar(&o.KubeConfing, "kubeconfig", o.KubeConfing, "Path to the kubeconfig file to use for CLI requests")


### PR DESCRIPTION
### Why

`-n` flag accepts multiple namespaces, but it break the `kubectl` compatibility.

### What

I added `multi-namespaces` `-m` flags to support finding secret data from multiple namespaces and prioritize the `kubectl` compatibility.

I updated docs according to this change.