### PR TITLE
Fix a command option name to be consistent with kubectl

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Usage:
   kubectl-secret-data [flags]
 
 Flags:
-  -A, --all-namespace             If present, find secrets from all namespaces
+  -A, --all-namespaces            If present, find secrets from all namespaces
       --cluster string            The name of the kubeconfig context to use
       --context string            The name of the kubeconfig cluster to use
   -h, --help                      help for kubectl-secret-data

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ type options struct {
 	Cluster         string
 	Output          string
 	Regex           string
-	AllNamespace    bool
+	AllNamespaces   bool
 }
 
 func newOptions() options {
@@ -51,7 +51,7 @@ func newOptions() options {
 		Namespace:       "",
 		MultiNamespaces: "",
 		Output:          "yaml",
-		AllNamespace:    false,
+		AllNamespaces:   false,
 	}
 }
 
@@ -77,5 +77,5 @@ func (o *options) parseFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVar(&o.KubeConfing, "kubeconfig", o.KubeConfing, "Path to the kubeconfig file to use for CLI requests")
 	cmd.PersistentFlags().StringVarP(&o.Output, "output", "o", o.Output, "The format of the result")
 	cmd.PersistentFlags().StringVarP(&o.Regex, "regex", "E", o.Regex, "The regular expression of secret name")
-	cmd.PersistentFlags().BoolVarP(&o.AllNamespace, "all-namespace", "A", o.AllNamespace, "If present, find secrets from all namespaces")
+	cmd.PersistentFlags().BoolVarP(&o.AllNamespaces, "all-namespaces", "A", o.AllNamespaces, "If present, find secrets from all namespaces")
 }


### PR DESCRIPTION
`kubectl-secret-data` has a option `--all-namespace`, but it should be `--all-namespaces` because it is more consistent with kubectl. The difference of trailing "s" might confuse users who are used to the kubectl.

kubectl uses `--all-namespaces` like below:
```
$ kubectl get -h | grep all-namespace
 Prints a table of the most important information about the specified resources. You can filter the list using a label selector and the --selector flag. If the desired resource type is namespaced you will only see results in your current namespace unless you pass --all-namespaces.
  -A, --all-namespaces=false: If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.
```