### PR TITLE
Issue 10: Pick default namespace if no namespace is provided

### DIFF
--- a/options.go
+++ b/options.go
@@ -115,7 +115,7 @@ func (o *Options) Complete(f cmdutil.Factory, args []string) error {
 
 	switch nTrue(o.Namespace != "", o.AllNamespaces, o.MultiNamespacesString != "") {
 	case 0:
-		return fmt.Errorf("must select at least a namespace")
+		o.Namespace = "default"
 	case 2, 3:
 		return fmt.Errorf("must choose one option to use for selecting namespace")
 	}


### PR DESCRIPTION
The default namespace is getting selected if no namespace is provided.
It was tested with following flows
1. Without any namespace - if secret present
```bash
❯ kubectl secretdata default-ns-secret -o json                                                                                                                       
{
    "default": {
        "default-ns-secret": {
            "password": "testpassword",
            "username": "testuser"
        }
    }
}

❯ kubectl secretdata default-ns-secret                                                                                                                               
default:
  default-ns-secret:
    password: testpassword
    username: testuser
```
3. Without any namespace - if secret does not exists
```bash
❯ kubectl secretdata default-ns-secret2                                                                                                                               
Error from server (NotFound): secrets "default-ns-secret2" not found
```
5. With all namespaces
```bash
❯ kubectl secretdata -A                                                                                                                                               
default:
  default-ns-secret:
    password: testpassword
    username: testuser
istio-system:
  istio-ca-secret:
    ca-cert.pem: |
      -----BEGIN CERTIFICATE-----
      .................................................
      -----END CERTIFICATE-----
    ca-key.pem: |
    -----BEGIN RSA PRIVATE KEY-----
    .................................................
    -----END RSA PRIVATE KEY-----
    cert-chain.pem: ""
    key.pem: ""
    root-cert.pem: |
      -----BEGIN CERTIFICATE-----
      .................................................
      -----END CERTIFICATE-----
kube-system:
  bootstrap-token-abc:
    auth-extra-groups: system:bootstrappers:kubeadm:default-node-token
    expiration: "2024-09-21T13:56:03Z"
test:
  test-ns-secret:
    password: testpassword2
    username: testuser2
```
7. With Multiple namespaces
```bash
❯ kubectl secretdata -m default,test                                                                                                                                             
default:
  default-ns-secret:
    password: testpassword
    username: testuser
test:
  test-ns-secret:
    password: testpassword2
    username: testuser2
```
Closes #10 